### PR TITLE
Add support for a more compact XML output

### DIFF
--- a/osmwriter/__init__.py
+++ b/osmwriter/__init__.py
@@ -1,15 +1,25 @@
+import sys
 from xml.sax.saxutils import XMLGenerator
 from six import text_type as t
 
 class OSMWriter(object):
-    def __init__(self, filename=None, fp=None):
+    def __init__(self, filename=None, fp=None, compact_formatting=False):
         if filename:
             self.filename = filename
             self.fp = open(self.filename, 'wb')
         elif fp:
             self.fp = fp
 
-        self.xmlfile = XMLGenerator(self.fp, 'utf-8')
+        if sys.version_info < (3, 2):
+            if compact_formatting:
+                # xml.sax.saxutils.XMLGenerator only supports outputting
+                # compact empty tags since 3.2.
+                raise ValueError('compact formatting requires Python 3.2+')
+            else:
+                self.xmlfile = XMLGenerator(self.fp, 'utf-8')
+        else:
+            self.xmlfile = XMLGenerator(self.fp, 'utf-8',
+                                        short_empty_elements=compact_formatting)
 
         self.xmlfile.startDocument()
         # TODO include version
@@ -98,5 +108,3 @@ class OSMWriter(object):
 
         self.xmlfile.characters("\n  ")
         self.xmlfile.endElement("relation")
-
-

--- a/osmwriter/tests.py
+++ b/osmwriter/tests.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from osmwriter import OSMWriter
 from six import StringIO
 import xml.etree.ElementTree as ET
@@ -22,6 +23,24 @@ class OSMWriterTestCase(unittest.TestCase):
         exected_output = ET.tostring(ET.fromstring('<?xml version="1.0" encoding="utf-8"?>\n<osm version="0.6" generator="osmwriter">\n  <node lat="10" version="2" lon="30" id="1">\n    <tag k="highway" v="yes"></tag>\n  </node>\n  <way id="1">\n    <nd ref="123"></nd>\n    <tag k="pub" v="yes"></tag>\n  </way>\n  <relation id="1">\n    <member ref="1" type="node" />\n    <member ref="2" role="outer" type="way" />\n    <tag k="type" v="boundary" />\n  </relation>\n</osm>'))
 
         self.assertEqual(output, exected_output)
+
+    if sys.version_info >= (3, 2):
+        def testCompactFormatting(self):
+            def generate_osm(compact_formatting):
+                stream = StringIO()
+                xml = OSMWriter(fp=stream, compact_formatting=compact_formatting)
+                xml.node(1, 10, 30, {"highway": "yes"}, version=2)
+                xml.way(1, {'pub': 'yes'}, [123])
+                xml.relation(1, {'type': 'boundary'}, [('node', 1), ('way', 2, 'outer')])
+                xml.close(close_file=False)
+                return stream.getvalue()
+            # Compact formatting produces smaller output.
+            normal_repr = generate_osm(compact_formatting=False)
+            compact_repr = generate_osm(compact_formatting=True)
+            self.assertLess(len(compact_repr), len(normal_repr))
+            # Compact formatting parses to the same infoset as normal formatting.
+            xml_from_normal_repr = ET.tostring(ET.fromstring(normal_repr))
+            xml_from_compact_repr = ET.tostring(ET.fromstring(compact_repr))
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 commands = {envpython} setup.py test
-


### PR DESCRIPTION
We deal with multi-megabyte .osm files. This shaves 5-6% off the XML size without any sacrifice to readability.